### PR TITLE
Don't use full url in plotly

### DIFF
--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -1309,7 +1309,7 @@ function nodeHash(node) {
  * - context._exportedPlot {boolean}
  */
 drawing.setClipUrl = function(s, localId, gd) {
-    s.attr('clip-path', getFullUrl(localId, gd));
+    s.attr('clip-path', 'url(#' + localId + ')');
 };
 
 function getFullUrl(localId, gd) {


### PR DESCRIPTION
This PR is to check the changes we made to the fork of plotly.
